### PR TITLE
feat: add CI and deploy GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm test -- --watch=false --browsers=ChromeHeadless

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build -- --base-href /bone-machine/
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/bone-machine
+
+      - id: deploy
+        uses: actions/deploy-pages@v4
+
+  release:
+    runs-on: ubuntu-latest
+    needs: deploy
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ github.run_number }}
+          release_name: Release v${{ github.run_number }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Summary
- CI workflow runs build and tests on PRs to `develop` and `main`
- Deploy workflow triggers on merge to `main` — builds, deploys to GitHub Pages at `abgoosht.github.io/bone-machine`, and creates a GitHub Release
- No dev environment deploy — `develop` is the integration gate only

## Test plan
- [ ] Merge this PR into `develop`
- [ ] Open a PR from `develop` into `main` and verify CI runs
- [ ] Merge into `main` and verify deploy and release are created

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)