### PR TITLE
test: verify branch protection blocks failing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
 
       - run: npm run build
 
-      - run: npm test -- --watch=false
+      - run: npm test -- --watch=false --browsers=ChromeHeadless


### PR DESCRIPTION
This PR intentionally breaks CI to verify the merge button is blocked when checks fail. Do not merge.