### PR TITLE
fix: correct deploy artifact path to dist/bone-machine/browser

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist/bone-machine
+          path: dist/bone-machine/browser
 
       - id: deploy
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Angular 21 CI build outputs to `dist/bone-machine/browser/` not `dist/bone-machine/`
- Previous deploy was uploading the wrong directory, causing a 404 on GitHub Pages

## Test plan
- [ ] Merge into `develop`
- [ ] Open PR from `develop` into `main`
- [ ] Merge and verify site loads at `abgoosht.github.io/bone-machine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)