### PR TITLE
fix: correct deploy artifact path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist/bone-machine
+          path: dist/bone-machine/browser
 
       - id: deploy
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Fixes 404 on GitHub Pages by correcting the deploy artifact path to `dist/bone-machine/browser`

## Test plan
- [ ] Merge and verify site loads at `abgoosht.github.io/bone-machine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)