### PR TITLE
chore: opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - develop
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to both CI and deploy workflows
- Opts into Node.js 24 now ahead of the forced rollout on June 2nd, 2026

## Test plan
- [ ] Verify CI passes with no Node.js 20 deprecation warnings
- [ ] Merge into `develop`, then open PR to `main` and verify deploy still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)