### PR TITLE
chore: update GitHub Actions to Node 24 native versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,14 @@ on:
       - develop
       - main
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,6 @@ permissions:
   pages: write
   id-token: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -21,9 +18,9 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -32,26 +29,21 @@ jobs:
 
       - run: npm run build -- --base-href /bone-machine/
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist/bone-machine/browser
 
       - id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   release:
     runs-on: ubuntu-latest
     needs: deploy
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create release
-        uses: actions/create-release@v1
+        run: gh release create v${{ github.run_number }} --title "Release v${{ github.run_number }}" --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ github.run_number }}
-          release_name: Release v${{ github.run_number }}
-          draft: false
-          prerelease: false


### PR DESCRIPTION
## Summary
- Updates all actions to Node 24 native versions
- Replaces deprecated `actions/create-release@v1` with `gh release create`
- Removes `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var

## Test plan
- [ ] Verify CI passes
- [ ] Merge and verify deploy + release work with no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)