### PR TITLE
Part 8: Player name fields with defaults and live editing

### DIFF
--- a/src/app/pages/landing/landing.constants.ts
+++ b/src/app/pages/landing/landing.constants.ts
@@ -1,0 +1,5 @@
+export const defaultPlayerNames: Record<number, string[]> = {
+  2: ['Us', 'Them', '', ''],
+  3: ['Me', 'You', 'Them', ''],
+  4: ['Me', 'You', 'Them', 'Backman'],
+};

--- a/src/app/pages/landing/landing.html
+++ b/src/app/pages/landing/landing.html
@@ -23,13 +23,33 @@
   <!-- Team name fields -->
   <section class="flex flex-col gap-3">
     <h2 class="text-sm uppercase tracking-widest text-gray-400">Player Names</h2>
-    <input type="text" placeholder="Player 1" class="w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 outline-none" />
-    <input type="text" placeholder="Player 2" class="w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 outline-none" />
+    <input
+      type="text"
+      [value]="playerNames()[0]"
+      (input)="updatePlayerName(0, $event)"
+      class="w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 outline-none"
+    />
+    <input
+      type="text"
+      [value]="playerNames()[1]"
+      (input)="updatePlayerName(1, $event)"
+      class="w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 outline-none"
+    />
     @if (playerCount() >= 3) {
-      <input type="text" placeholder="Player 3" class="w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 outline-none" />
+      <input
+        type="text"
+        [value]="playerNames()[2]"
+        (input)="updatePlayerName(2, $event)"
+        class="w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 outline-none"
+      />
     }
     @if (playerCount() >= 4) {
-      <input type="text" placeholder="Player 4" class="w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 outline-none" />
+      <input
+        type="text"
+        [value]="playerNames()[3]"
+        (input)="updatePlayerName(3, $event)"
+        class="w-full bg-gray-800 rounded-xl px-4 py-3 text-white placeholder-gray-500 outline-none"
+      />
     }
   </section>
 

--- a/src/app/pages/landing/landing.ts
+++ b/src/app/pages/landing/landing.ts
@@ -1,5 +1,6 @@
-import { Component, signal } from '@angular/core';
+import { Component, signal, effect } from '@angular/core';
 import { Slider } from '../../components/slider/slider';
+import { defaultPlayerNames } from './landing.constants';
 
 @Component({
   selector: 'bm-landing',
@@ -11,6 +12,22 @@ export class Landing {
   readonly scoreOptions = [150, 200, 250, 300, 500];
   readonly playerCountOptions = [2, 3, 4];
 
-  targetScore = signal(300);
+  targetScore = signal(150);
   playerCount = signal(2);
+  playerNames = signal([...defaultPlayerNames[2]]);
+
+  constructor() {
+    effect(() => {
+      this.playerNames.set([...defaultPlayerNames[this.playerCount()]]);
+    });
+  }
+
+  updatePlayerName(index: number, event: Event): void {
+    const name = (event.target as HTMLInputElement).value;
+    this.playerNames.update(names => {
+      const updatedNames = [...names];
+      updatedNames[index] = name;
+      return updatedNames;
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Extracts default player names to `landing.constants.ts`
- Adds `playerNames` signal with defaults per player count
- Names reset to defaults when player count changes
- Fields are freely editable
- Default target score set to 150

Closes #19

-Claudia