### PR TITLE
Part 9 + Scorekeeping: navigation, game logic, and win condition

### DIFF
--- a/src/app/models/game-config.ts
+++ b/src/app/models/game-config.ts
@@ -1,0 +1,5 @@
+export interface GameConfig {
+  targetScore: number;
+  playerCount: number;
+  playerNames: string[];
+}

--- a/src/app/pages/landing/landing.constants.ts
+++ b/src/app/pages/landing/landing.constants.ts
@@ -1,5 +1,5 @@
 export const defaultPlayerNames: Record<number, string[]> = {
-  2: ['Us', 'Them', '', ''],
-  3: ['Me', 'You', 'Them', ''],
+  2: ['Us', 'Them'],
+  3: ['Me', 'You', 'Them'],
   4: ['Me', 'You', 'Them', 'Backman'],
 };

--- a/src/app/pages/landing/landing.html
+++ b/src/app/pages/landing/landing.html
@@ -1,4 +1,4 @@
-<div class="flex flex-col min-h-screen bg-gray-950 text-white px-6 py-10 gap-10">
+<div class="flex flex-col min-h-screen bg-gray-950 text-white px-6 py-10 pb-32 gap-10">
 
   <!-- Score selector -->
   <section class="flex flex-col items-center gap-3 w-full">
@@ -54,8 +54,8 @@
   </section>
 
   <!-- Start button -->
-  <div class="mt-auto">
-    <button class="w-full bg-white text-gray-950 font-bold text-lg rounded-xl py-4">
+  <div class="fixed bottom-0 left-0 right-0 p-6 bg-gray-950">
+    <button (click)="startGame()" class="w-full bg-white text-gray-950 font-bold text-lg rounded-xl py-4">
       Start Game
     </button>
   </div>

--- a/src/app/pages/landing/landing.ts
+++ b/src/app/pages/landing/landing.ts
@@ -1,6 +1,8 @@
 import { Component, signal, effect } from '@angular/core';
+import { Router } from '@angular/router';
 import { Slider } from '../../components/slider/slider';
 import { defaultPlayerNames } from './landing.constants';
+import { GameConfig } from '../../models/game-config';
 
 @Component({
   selector: 'bm-landing',
@@ -16,7 +18,7 @@ export class Landing {
   playerCount = signal(2);
   playerNames = signal([...defaultPlayerNames[2]]);
 
-  constructor() {
+  constructor(private router: Router) {
     effect(() => {
       this.playerNames.set([...defaultPlayerNames[this.playerCount()]]);
     });
@@ -29,5 +31,14 @@ export class Landing {
       updatedNames[index] = name;
       return updatedNames;
     });
+  }
+
+  startGame(): void {
+    const config: GameConfig = {
+      targetScore: this.targetScore(),
+      playerCount: this.playerCount(),
+      playerNames: this.playerNames().slice(0, this.playerCount()),
+    };
+    this.router.navigate(['/game'], { state: { config } });
   }
 }

--- a/src/app/pages/landing/landing.ts
+++ b/src/app/pages/landing/landing.ts
@@ -37,7 +37,7 @@ export class Landing {
     const config: GameConfig = {
       targetScore: this.targetScore(),
       playerCount: this.playerCount(),
-      playerNames: this.playerNames().slice(0, this.playerCount()),
+      playerNames: this.playerNames().filter(name => name.trim().length > 0),
     };
     this.router.navigate(['/game'], { state: { config } });
   }

--- a/src/app/pages/scorekeeping/scorekeeping.html
+++ b/src/app/pages/scorekeeping/scorekeeping.html
@@ -1,14 +1,35 @@
 @if (config(); as gameConfig) {
-  <div class="flex flex-col min-h-screen bg-gray-950 text-white p-6">
-    <p class="text-gray-400 text-sm text-center mb-6">First to {{ gameConfig.targetScore }} wins</p>
+  <div class="flex flex-col min-h-screen bg-gray-950 text-white p-4 gap-4">
+
+    <p class="text-gray-400 text-sm text-center">First to {{ gameConfig.targetScore }} wins</p>
+
     <div class="flex flex-col gap-4 flex-1">
-      @for (name of gameConfig.playerNames; track name) {
-        <div class="flex flex-col items-center flex-1 bg-gray-800 rounded-2xl p-4 gap-4">
-          <span class="font-bold text-lg">{{ name }}</span>
-          <span class="text-4xl font-bold tabular-nums">0</span>
+      @for (name of gameConfig.playerNames; track $index) {
+        <div
+          class="flex items-center rounded-2xl px-6 py-4 gap-4 transition-colors"
+          [class]="$index === winner() ? 'bg-green-600' : 'bg-gray-800'"
+        >
+          <span class="font-bold text-lg flex-1">{{ name }}</span>
+          <button
+            (click)="decrement($index)"
+            class="w-14 h-14 rounded-full bg-gray-700 text-2xl font-bold active:scale-95 transition-transform"
+          >−</button>
+          <span class="text-4xl font-bold tabular-nums w-20 text-center">{{ scores()[$index] }}</span>
+          <button
+            (click)="increment($index)"
+            class="w-14 h-14 rounded-full bg-gray-700 text-2xl font-bold active:scale-95 transition-transform"
+          >+</button>
         </div>
       }
     </div>
+
+    @if (winner() !== -1) {
+      <div class="text-center py-4">
+        <p class="text-2xl font-bold">{{ gameConfig.playerNames[winner()] }} wins!</p>
+        <a href="/" class="text-gray-400 underline text-sm mt-2 block">Play again</a>
+      </div>
+    }
+
   </div>
 } @else {
   <div class="flex items-center justify-center min-h-screen bg-gray-950 text-gray-400">

--- a/src/app/pages/scorekeeping/scorekeeping.html
+++ b/src/app/pages/scorekeeping/scorekeeping.html
@@ -1,1 +1,17 @@
-<p>scorekeeping works!</p>
+@if (config(); as gameConfig) {
+  <div class="flex flex-col min-h-screen bg-gray-950 text-white p-6">
+    <p class="text-gray-400 text-sm text-center mb-6">First to {{ gameConfig.targetScore }} wins</p>
+    <div class="flex flex-col gap-4 flex-1">
+      @for (name of gameConfig.playerNames; track name) {
+        <div class="flex flex-col items-center flex-1 bg-gray-800 rounded-2xl p-4 gap-4">
+          <span class="font-bold text-lg">{{ name }}</span>
+          <span class="text-4xl font-bold tabular-nums">0</span>
+        </div>
+      }
+    </div>
+  </div>
+} @else {
+  <div class="flex items-center justify-center min-h-screen bg-gray-950 text-gray-400">
+    <p>No game config found. <a href="/" class="text-white underline">Go back</a></p>
+  </div>
+}

--- a/src/app/pages/scorekeeping/scorekeeping.ts
+++ b/src/app/pages/scorekeeping/scorekeeping.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, signal } from '@angular/core';
+import { Component, OnInit, signal, computed } from '@angular/core';
 import { GameConfig } from '../../models/game-config';
 
 @Component({
@@ -9,11 +9,37 @@ import { GameConfig } from '../../models/game-config';
 })
 export class Scorekeeping implements OnInit {
   config = signal<GameConfig | null>(null);
+  scores = signal<number[]>([]);
+
+  winner = computed(() => {
+    const gameConfig = this.config();
+    if (!gameConfig) return -1;
+    return this.scores().findIndex(score => score >= gameConfig.targetScore);
+  });
 
   ngOnInit(): void {
     const state = history.state as { config: GameConfig } | undefined;
     if (state?.config) {
       this.config.set(state.config);
+      this.scores.set(state.config.playerNames.map(() => 0));
     }
+  }
+
+  increment(playerIndex: number): void {
+    if (this.winner() !== -1) return;
+    this.scores.update(currentScores => {
+      const updatedScores = [...currentScores];
+      updatedScores[playerIndex] += 5;
+      return updatedScores;
+    });
+  }
+
+  decrement(playerIndex: number): void {
+    if (this.winner() !== -1) return;
+    this.scores.update(currentScores => {
+      const updatedScores = [...currentScores];
+      updatedScores[playerIndex] = Math.max(0, updatedScores[playerIndex] - 5);
+      return updatedScores;
+    });
   }
 }

--- a/src/app/pages/scorekeeping/scorekeeping.ts
+++ b/src/app/pages/scorekeeping/scorekeeping.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
+import { GameConfig } from '../../models/game-config';
 
 @Component({
   selector: 'bm-scorekeeping',
@@ -6,4 +7,13 @@ import { Component } from '@angular/core';
   templateUrl: './scorekeeping.html',
   styleUrl: './scorekeeping.scss',
 })
-export class Scorekeeping {}
+export class Scorekeeping implements OnInit {
+  config = signal<GameConfig | null>(null);
+
+  ngOnInit(): void {
+    const state = history.state as { config: GameConfig } | undefined;
+    if (state?.config) {
+      this.config.set(state.config);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Start button collects target score, player count, and names and navigates to `/game` via router state
- Fixed button pinned to bottom of landing page on mobile
- Introduces `GameConfig` model in `src/app/models/`
- Scorekeeping page receives config via `history.state`
- Plus/minus buttons update scores per player (+5/-5, floor at 0)
- First player to hit target score wins — column turns green
- Game over state with player name and play again link
- Bug fix: empty player names filtered before passing to scorekeeping
- `defaultPlayerNames` constants cleaned up (no empty strings)

Closes #20

## Test plan
- [ ] Start button always visible on mobile
- [ ] Correct number of player cards for 2, 3, and 4 players
- [ ] +/- buttons update scores correctly
- [ ] Score cannot go below 0
- [ ] Winning column turns green
- [ ] Play again link returns to landing

-Claudia