### PR TITLE
TD: Disable zoom on mobile via viewport meta

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Bone Machine</title>
     <base href="/" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Adds `user-scalable=no` and `maximum-scale=1` to viewport meta in `index.html`
- Prevents accidental zoom when tapping +/- buttons rapidly

Closes #29

-Claudia