### PR TITLE
TD: Add app banner with version number

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,15 @@ jobs:
 
       - run: npm ci
 
+      - name: Bump patch version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version patch --no-git-tag-version
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to $(node -p \"require('./package.json').version\") [skip ci]"
+          git push
+
       - run: npm run build -- --base-href /bone-machine/
 
       - uses: actions/upload-pages-artifact@v5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bone-machine",
-  "version": "0.0.0",
+  "version": "0.0.9",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,1 +1,6 @@
+<header class="bg-gray-950 text-white text-center py-4 border-b border-gray-800">
+  <p class="text-2xl font-bold">Bone Machine</p>
+  <p class="text-xs text-gray-400">(v{{ version }})</p>
+</header>
+
 <router-outlet />

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,5 +1,6 @@
-import { Component, signal } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { version } from '../../package.json';
 
 @Component({
   selector: 'bm-root',
@@ -8,5 +9,5 @@ import { RouterOutlet } from '@angular/router';
   styleUrl: './app.scss',
 })
 export class App {
-  protected readonly title = signal('bone-machine');
+  readonly version = version;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "ES2022",
-    "module": "preserve"
+    "module": "preserve",
+    "resolveJsonModule": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
## Summary
- Persistent header on every page showing "Bone Machine" and current version
- Version read directly from `package.json` via `resolveJsonModule`
- Sets initial semantic version to `0.0.9`
- GitHub Actions auto-bumps patch version on every deploy to main (uses `[skip ci]` to prevent loop)

Closes #33

-Claudia