### PR TITLE
TD: Fix shell quoting in version bump workflow step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           npm version patch --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
           git add package.json package-lock.json
-          git commit -m "chore: bump version to $(node -p \"require('./package.json').version\") [skip ci]"
+          git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
           git push
 
       - run: npm run build -- --base-href /bone-machine/


### PR DESCRIPTION
## Summary
- Fixes syntax error in deploy workflow caused by nested quote escaping
- Captures version in a variable before using it in the commit message

-Claudia