### PR TITLE
TD: Remove auto version bump from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,16 +27,6 @@ jobs:
 
       - run: npm ci
 
-      - name: Bump patch version
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm version patch --no-git-tag-version
-          NEW_VERSION=$(node -p "require('./package.json').version")
-          git add package.json package-lock.json
-          git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
-          git push
-
       - run: npm run build -- --base-href /bone-machine/
 
       - uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## Summary
- Removes the auto version bump step that was failing due to branch protection
- Version will be bumped manually in `package.json` as part of each PR

-Claudia