### PR TITLE
Scorekeeping fixes and content updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bone-machine",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/pages/landing/landing.constants.ts
+++ b/src/app/pages/landing/landing.constants.ts
@@ -1,5 +1,5 @@
 export const defaultPlayerNames: Record<number, string[]> = {
-  2: ['Us', 'Them'],
-  3: ['Me', 'You', 'Them'],
-  4: ['Me', 'You', 'Them', 'Backman'],
+  2: ['US', 'THEM'],
+  3: ['ME', 'YOU', 'THEM'],
+  4: ['ME', 'YOU', 'THEM', 'BACKMAN'],
 };

--- a/src/app/pages/landing/landing.html
+++ b/src/app/pages/landing/landing.html
@@ -56,7 +56,7 @@
   <!-- Start button -->
   <div class="fixed bottom-0 left-0 right-0 p-6 bg-gray-950">
     <button (click)="startGame()" class="w-full bg-white text-gray-950 font-bold text-lg rounded-xl py-4">
-      Start Game
+      Let's Bone
     </button>
   </div>
 

--- a/src/app/pages/landing/landing.ts
+++ b/src/app/pages/landing/landing.ts
@@ -11,7 +11,7 @@ import { GameConfig } from '../../models/game-config';
   styleUrl: './landing.scss',
 })
 export class Landing {
-  readonly scoreOptions = [150, 200, 250, 300, 500];
+  readonly scoreOptions = [150, 200, 250];
   readonly playerCountOptions = [2, 3, 4];
 
   targetScore = signal(150);

--- a/src/app/pages/scorekeeping/scorekeeping.html
+++ b/src/app/pages/scorekeeping/scorekeeping.html
@@ -26,13 +26,13 @@
     @if (winner() !== -1) {
       <div class="text-center py-4">
         <p class="text-2xl font-bold">{{ gameConfig.playerNames[winner()] }} wins!</p>
-        <a href="/" class="text-gray-400 underline text-sm mt-2 block">Play again</a>
+        <button (click)="playAgain()" class="text-gray-400 underline text-sm mt-2 block">Play again</button>
       </div>
     }
 
   </div>
 } @else {
   <div class="flex items-center justify-center min-h-screen bg-gray-950 text-gray-400">
-    <p>No game config found. <a href="/" class="text-white underline">Go back</a></p>
+    <p>No game config found. <button (click)="playAgain()" class="text-white underline">Go back</button></p>
   </div>
 }

--- a/src/app/pages/scorekeeping/scorekeeping.html
+++ b/src/app/pages/scorekeeping/scorekeeping.html
@@ -1,5 +1,5 @@
 @if (config(); as gameConfig) {
-  <div class="flex flex-col min-h-screen bg-gray-950 text-white p-4 gap-4">
+  <div class="flex flex-col min-h-screen bg-gray-950 text-white p-4 gap-4" [class.pb-32]="winner() !== -1">
 
     <p class="text-gray-400 text-sm text-center">First to {{ gameConfig.targetScore }} wins</p>
 
@@ -26,7 +26,12 @@
     @if (winner() !== -1) {
       <div class="text-center py-4">
         <p class="text-2xl font-bold">{{ gameConfig.playerNames[winner()] }} wins!</p>
-        <button (click)="playAgain()" class="text-gray-400 underline text-sm mt-2 block">Play again</button>
+      </div>
+
+      <div class="fixed bottom-0 left-0 right-0 p-6 bg-gray-950">
+        <button (click)="playAgain()" class="w-full bg-green-500 text-white font-bold text-lg rounded-xl py-4 touch-manipulation">
+          Play Again
+        </button>
       </div>
     }
 

--- a/src/app/pages/scorekeeping/scorekeeping.ts
+++ b/src/app/pages/scorekeeping/scorekeeping.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, signal, computed } from '@angular/core';
+import { Router } from '@angular/router';
 import { GameConfig } from '../../models/game-config';
 
 @Component({
@@ -16,6 +17,8 @@ export class Scorekeeping implements OnInit {
     if (!gameConfig) return -1;
     return this.scores().findIndex(score => score >= gameConfig.targetScore);
   });
+
+  constructor(private router: Router) {}
 
   ngOnInit(): void {
     const state = history.state as { config: GameConfig } | undefined;
@@ -41,5 +44,9 @@ export class Scorekeeping implements OnInit {
       updatedScores[playerIndex] = Math.max(0, updatedScores[playerIndex] - 5);
       return updatedScores;
     });
+  }
+
+  playAgain(): void {
+    this.router.navigate(['/']);
   }
 }

--- a/src/app/pages/scorekeeping/scorekeeping.ts
+++ b/src/app/pages/scorekeeping/scorekeeping.ts
@@ -38,7 +38,6 @@ export class Scorekeeping implements OnInit {
   }
 
   decrement(playerIndex: number): void {
-    if (this.winner() !== -1) return;
     this.scores.update(currentScores => {
       const updatedScores = [...currentScores];
       updatedScores[playerIndex] = Math.max(0, updatedScores[playerIndex] - 5);

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -4,6 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
+    "rootDir": "./src",
     "types": ["vitest/globals"]
   },
   "include": ["src/**/*.d.ts", "src/**/*.spec.ts"]


### PR DESCRIPTION
## Summary
- Fix Play Again 404 on GitHub Pages — use router navigation (closes #45)
- Score options updated to 150, 200, 250 (closes #46)
- Default player names capitalized (closes #47)
- Start Game renamed to "Let's Bone" (closes #48)
- Allow minus button after win to undo accidental win (closes #42)
- Play Again pinned to bottom as full-width green button (closes #44)
- Version bumped to 0.0.11

-Claudia